### PR TITLE
Update notes.html

### DIFF
--- a/docs/v4/notes.html
+++ b/docs/v4/notes.html
@@ -27,7 +27,6 @@
   <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
   <link rel="stylesheet" href="_static/css/ethers.css" type="text/css" />
-  <link rel="stylesheet" href="_static/css/ethers.css" type="text/css" />
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="Testing" href="testing.html" />


### PR DESCRIPTION
Duplicate Link Tags: There are duplicate link tags for the ethers.css stylesheet. I removed one of them to avoid unnecessary loading of the same resource twice.

html
Copy code
<link rel="stylesheet" href="_static/css/ethers.css" type="text/css" />